### PR TITLE
Include the Nextflow DKFZ config file by default

### DIFF
--- a/{{ cookiecutter.repo_name }}/config/nxf_dkfz.config
+++ b/{{ cookiecutter.repo_name }}/config/nxf_dkfz.config
@@ -25,6 +25,7 @@ process {
         time: 48.h
     ]
     executor = 'lsf'
+    clusterOptions = '-L /bin/bash'
     scratch  = '$SCRATCHDIR/$LSB_JOBID'
 }
 executor {

--- a/{{ cookiecutter.repo_name }}/config/nxf_dkfz.config
+++ b/{{ cookiecutter.repo_name }}/config/nxf_dkfz.config
@@ -1,0 +1,36 @@
+// source of the config file: https://nf-co.re/configs/dkfz/
+// https://github.com/nf-core/configs/blob/master/conf/dkfz.config
+
+params {
+    config_profile_description = 'Deutsches Krebsforschungszentrum (DKFZ) HPC cluster profile provided by nf-core/configs'
+    config_profile_contact     = 'Kübra Narcı kuebra.narci@dkfz-heidelberg.de'
+    config_profile_name        = 'DKFZ cluster'
+ 
+ 
+    max_cpus                   = 30
+    max_memory                 = '250.GB'
+    max_time                   = '48.h'
+}
+ 
+ 
+singularity {
+    enabled    = true
+    autoMounts = true
+}
+ 
+process {
+    resourceLimits = [
+        memory: 250.GB,
+        cpus: 30,
+        time: 48.h
+    ]
+    executor = 'lsf'
+    scratch  = '$SCRATCHDIR/$LSB_JOBID'
+}
+executor {
+    name            = 'lsf'
+    perTaskReserve  = false
+    perJobMemLimit  = true
+    queueSize       = 10
+    submitRateLimit = '3 sec'
+}


### PR DESCRIPTION
Hi David,

I suggest to include the Nextflow DKFZ config file by default in the config directory of the cookiecutter template, so we don't have to create it manually for each Nextflow pipeline.

Best,
Vithusan